### PR TITLE
Update dtu_we_controller_fcns.f90

### DIFF
--- a/src/dtu_we_controller/dtu_we_controller_fcns.f90
+++ b/src/dtu_we_controller/dtu_we_controller_fcns.f90
@@ -228,7 +228,8 @@ function PID2(stepno,dt,kgain,PIDvar,error,added_term)
       write(*, *)  'PIDvar%Kdif(1)=', PIDvar%Kdif(1)
       write(*, *)  'Padded_term=', added_term
       write(*, *)  'PIDvar%outset=', PIDvar%outset
-      pause
+      write(*, *)  'Press [Enter] to continue..' 
+      read(*, *) 
    endif
    ! Satisfy max velocity
    if (PIDvar%velmax .gt. eps) then


### PR DESCRIPTION
Replaced obsolete Fortran function PAUSE with "Press enter to continue"