### PR TITLE
Update 'get_git_version.bat' to generate 'git_version.inc'

### DIFF
--- a/src/get_git_version.bat
+++ b/src/get_git_version.bat
@@ -13,6 +13,9 @@ git rev-list %last_tag%..HEAD --count > tmp.txt
 set /p rev_count_since_tag=<tmp.txt
 
 echo %last_tag%.dev%rev_count_since_tag%.%rev_hash% > git_version.txt
+
+echo text35='%last_tag%.dev%rev_count_since_tag%.%rev_hash%' > ./src/dtu_we_controller/git_version.inc
+
 del tmp.txt
 
-VersionScript.exe
+


### PR DESCRIPTION
Proposed solution to avoid using 'VersionScript' to generate 'git_version.inc'. This eliminates the need for 'VersionScript.exe'. Found to be working well.